### PR TITLE
Fix/untranslated assets in text

### DIFF
--- a/rosey/features/build/rosey-build-assets.feature
+++ b/rosey/features/build/rosey-build-assets.feature
@@ -72,7 +72,7 @@ Feature: Rosey Build Assets
       {}
       """
     When I run my program with the flags:
-      | build                   |
-      | --exclusions "[png]{3}" |
+      | build                    |
+      | --exclusions "[png]{3}$" |
     Then I should see the file "dist/translated_site/about.htm"
     And I should see "true" in "dist/translated_site/about.json"

--- a/rosey/features/build/rosey-build-resilience.feature
+++ b/rosey/features/build/rosey-build-resilience.feature
@@ -49,3 +49,28 @@ Feature: Rosey Build Resilience
       | loop |  |
     And I should see '<!--Comment-->' in "dist/translated_site/airy/index.html"
     And I should see '<!DOCTYPE html>' in "dist/translated_site/airy/index.html"
+
+  Scenario: Rosey build doesn't break in translation img srcs
+    Given I have a "dist/site/index.html" file with the content:
+      """
+      <html>
+      <body>
+      <div data-rosey="container">
+        <img src="https://ryancollins.website/images/rodents/souslik.png" />
+      </div>
+      </body>
+      </html>
+      """
+    And I have a "rosey/locales/fr.json" file with the content:
+      """
+      {
+        "container": {
+          "original": "<img src=\"https://ryancollins.website/images/rodents/souslik.png\">",
+          "value": "<img src=\"https://ryancollins.website/images/rodents/souslik.png\">"
+        }
+      }
+      """
+    When I run my program with the flags:
+      | build |
+    Then I should see a selector 'img' in "dist/translated_site/fr/index.html" with the attributes:
+      | src | https://ryancollins.website/images/rodents/souslik.png |

--- a/rosey/src/runners/builder.rs
+++ b/rosey/src/runners/builder.rs
@@ -128,7 +128,7 @@ impl RoseyBuilder {
         let config = &self.options.config;
         let source_folder = &config.source;
         let walker: (Vec<_>, Vec<_>) =
-            globwalk::GlobWalkerBuilder::from_patterns(&source_folder, &["**/*.{html,json}"])
+            globwalk::GlobWalkerBuilder::from_patterns(source_folder, &["**/*.{html,json}"])
                 .build()
                 .unwrap()
                 .into_iter()
@@ -149,7 +149,7 @@ impl RoseyBuilder {
     fn find_locale_overwrite(&self, path: &Path) -> Option<&String> {
         let config = &self.options.config;
         let source_folder = &config.source;
-        let relative_path = path.strip_prefix(&source_folder).unwrap();
+        let relative_path = path.strip_prefix(source_folder).unwrap();
         self.translations.keys().find(|key| {
             relative_path
                 .parent()
@@ -192,7 +192,7 @@ impl RoseyBuilder {
     pub fn process_file_overrides(&self, path: &Path) {
         let config = &self.options.config;
         let source_folder = &config.source;
-        let relative_path = path.strip_prefix(&source_folder).unwrap();
+        let relative_path = path.strip_prefix(source_folder).unwrap();
         self.translations
             .par_iter()
             .filter(|(locale, _)| source_folder.join(locale).join(relative_path).exists())
@@ -204,7 +204,7 @@ impl RoseyBuilder {
     pub fn output_file(&self, locale: &str, relative_path: &Path, content: String) {
         let config = &self.options.config;
         let dest_folder = &config.dest.join(locale);
-        let dest_path = dest_folder.join(&relative_path);
+        let dest_path = dest_folder.join(relative_path);
         if let Some(parent) = dest_path.parent() {
             create_dir_all(parent).unwrap();
         }

--- a/rosey/src/runners/builder/html.rs
+++ b/rosey/src/runners/builder/html.rs
@@ -33,7 +33,7 @@ impl RoseyBuilder {
     pub fn process_html_file(&self, file: &Path) {
         let config = &self.options.config;
         let source_folder = &config.source;
-        let relative_path = file.strip_prefix(&source_folder).unwrap();
+        let relative_path = file.strip_prefix(source_folder).unwrap();
         let dest_folder = &config.dest;
         let images_source = config.images_source.as_ref().unwrap_or(&config.source);
 
@@ -60,7 +60,7 @@ impl RoseyBuilder {
             page.rewrite_assets();
             page.rewrite_anchors();
 
-            let output_path = dest_folder.join(&relative_path);
+            let output_path = dest_folder.join(relative_path);
             page.output_file(&output_path);
             return;
         }
@@ -70,7 +70,7 @@ impl RoseyBuilder {
 
         let output_path = dest_folder
             .join(&config.default_language)
-            .join(&relative_path);
+            .join(relative_path);
         page.output_file(&output_path);
         self.output_redirect_file(&config.default_language, relative_path);
 
@@ -82,7 +82,7 @@ impl RoseyBuilder {
             page.rewrite_assets();
             page.rewrite_anchors();
 
-            let output_path = dest_folder.join(key).join(&relative_path);
+            let output_path = dest_folder.join(key).join(relative_path);
             page.output_file(&output_path);
         });
     }
@@ -105,9 +105,9 @@ impl RoseyBuilder {
         };
 
         let mut alternates = String::default();
-        for key in (&self.translations)
-            .iter()
-            .map(|(key, _)| key)
+        for key in self
+            .translations
+            .keys()
             .chain(std::iter::once(&config.default_language))
             .filter(|key| *key != locale)
         {
@@ -119,9 +119,9 @@ impl RoseyBuilder {
         }
 
         let mut lookup: BTreeMap<String, &str> = BTreeMap::default();
-        for key in (&self.translations)
-            .iter()
-            .map(|(key, _)| key)
+        for key in self
+            .translations
+            .keys()
             .chain(std::iter::once(&config.default_language))
         {
             let mut split = key.split('-');
@@ -664,7 +664,7 @@ impl<'a> RoseyPage<'a> {
             create_dir_all(parent).unwrap();
         }
 
-        if let Ok(file) = File::create(&output_path) {
+        if let Ok(file) = File::create(output_path) {
             let writer = BufWriter::new(file);
             let mut serializer = RoseySerializer::new(writer);
             if Serialize::serialize(

--- a/rosey/src/runners/builder/html/utils.rs
+++ b/rosey/src/runners/builder/html/utils.rs
@@ -91,6 +91,8 @@ impl<'a> TokenSink for &mut TranslationRewriter<'a> {
                                 self.locale_key,
                             ) {
                                 write!(self.result, "/{translated_asset}").expect("Failed to rewrite content - custom asset attribute");
+                            } else {
+                                write!(self.result, "{}", attr.value).expect("Failed to rewrite content - skipping custom asset attribute");
                             }
                         }
                         ("img" | "video" | "audio" | "source", "src", _) => {
@@ -100,6 +102,8 @@ impl<'a> TokenSink for &mut TranslationRewriter<'a> {
                                 self.locale_key,
                             ) {
                                 write!(self.result, "/{translated_asset}").expect("Failed to rewrite content - asset attribute");
+                            } else {
+                                write!(self.result, "{}", attr.value).expect("Failed to rewrite content - skipping asset attribute");
                             }
                         }
                         ("a", "href", _) if has_download => {
@@ -109,6 +113,8 @@ impl<'a> TokenSink for &mut TranslationRewriter<'a> {
                                 self.locale_key,
                             ) {
                                 write!(self.result, "/{translated_asset}").expect("Failed to rewrite content - download link");
+                            } else {
+                                write!(self.result, "{}", attr.value).expect("Failed to rewrite content - skipping download link");
                             }
                         }
                         ("a", "href", _) if !has_download => {
@@ -144,6 +150,8 @@ impl<'a> TokenSink for &mut TranslationRewriter<'a> {
                                             self.locale_key,
                                         ) {
                                             return format!("/{} {}", translated_src, width);
+                                        } else {
+                                            return format!("/{} {}", src, width);
                                         }
                                     }
                                     original_part.to_string()

--- a/rosey/src/runners/generator.rs
+++ b/rosey/src/runners/generator.rs
@@ -49,7 +49,7 @@ impl RoseyGenerator {
         create_dir_all(locale_folder).unwrap();
         let output = self.locale.output(config.version);
 
-        if let Ok(file) = File::create(&locale_dest) {
+        if let Ok(file) = File::create(locale_dest) {
             let mut writer = BufWriter::new(file);
             if writer.write(output.as_bytes()).is_err() {
                 eprintln!("Failed to write: {locale_dest:?}")

--- a/rosey/src/runners/generator/json.rs
+++ b/rosey/src/runners/generator/json.rs
@@ -17,7 +17,7 @@ impl RoseyGenerator {
             return;
         }
 
-        let source = serde_json::from_str::<Value>(&read_to_string(&file).unwrap());
+        let source = serde_json::from_str::<Value>(&read_to_string(file).unwrap());
         let schema = serde_json::from_str::<Value>(&read_to_string(&schema_path).unwrap());
 
         if source.is_err() {


### PR DESCRIPTION
This PR fixes asset attributes in translations being deleted when they don't have a translated asset (e.g. an image with an external source). Instead if we can't find a translated asset we leave the attribute as is.

Also fixes some lints and a flaky regex test. 