### PR TITLE
Don't insert HTML into titles, scripts, and styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* `<title>`, `<script>` and `<style>` elements will no longer be wordwrapped when the `--wrap` flag is used.
+
 ## v2.0.3 (March 15, 2023)
 
 * Add support for wordwrapping Thai, with `rosey build --wrap "th"`.

--- a/rosey/features/build/rosey-build-wordwrap.feature
+++ b/rosey/features/build/rosey-build-wordwrap.feature
@@ -190,9 +190,9 @@ Feature: Rosey Build Word Wrap
       """
       <html>
       <body>
-        <div data-rosey="p">
-          <p>Hello World</p>
-        </div>
+      <div data-rosey="p">
+      <p>Hello World</p>
+      </div>
       </body>
       </html>
       """
@@ -214,3 +214,38 @@ Feature: Rosey Build Word Wrap
     Then I should see a selector 'div > p > span:nth-of-type(2)' in "dist/translated_site/ja-jp/index.html" with the attributes:
       | style     | white-space: nowrap; |
       | innerText | 世界                 |
+
+  Scenario: Rosey build won't wordwrap elements which shouldn't contain HTML
+    Given I have a "dist/site/index.html" file with the content:
+      """
+      <html>
+      <head>
+      <title data-rosey="hello">Hello World</title>
+      </head>
+      <body>
+      <script data-rosey="hello">Hello World</script>
+      <style data-rosey="hello">Hello World</style>
+      </body>
+      </html>
+      """
+    And I have a "rosey/locales/ja-jp.json" file with the content:
+      """
+      {
+        "hello": {
+          "original": "Hello World",
+          "value": "こんにちは世界"
+        }
+      }
+      """
+    When I run my program with the flags:
+      | build          |
+      | --wrap "ja-jp" |
+    Then I should see a selector 'title' in "dist/translated_site/ja-jp/index.html" with the attributes:
+      | innerText  | こんにちは世界 |
+      | data-rosey | hello        |
+    Then I should see a selector 'style' in "dist/translated_site/ja-jp/index.html" with the attributes:
+      | innerText  | こんにちは世界 |
+      | data-rosey | hello        |
+    Then I should see a selector 'script' in "dist/translated_site/ja-jp/index.html" with the attributes:
+      | innerText  | こんにちは世界 |
+      | data-rosey | hello        |

--- a/rosey/src/runners/builder/html.rs
+++ b/rosey/src/runners/builder/html.rs
@@ -286,8 +286,7 @@ impl<'a> RoseyPage<'a> {
                     });
 
                     let element_data = node.as_element().unwrap();
-                    let element_name = element_data.name.local.to_string();
-                    let should_prevent_wrap = UNSUPPORTED_WRAP_ELEMENTS.contains(&element_name.as_str());
+                    let should_prevent_wrap = UNSUPPORTED_WRAP_ELEMENTS.contains(&&element_data.name.local[..]);
 
                     if let Some(content) = translation.get(key) {
                         let content = if content.contains('<') {

--- a/rosey/src/runners/builder/html.rs
+++ b/rosey/src/runners/builder/html.rs
@@ -29,6 +29,8 @@ use sha2::{Digest, Sha256};
 
 use crate::RoseyTranslation;
 
+const UNSUPPORTED_WRAP_ELEMENTS: [&str; 3] = ["title", "script", "style"];
+
 impl RoseyBuilder {
     pub fn process_html_file(&self, file: &Path) {
         let config = &self.options.config;
@@ -283,6 +285,10 @@ impl<'a> RoseyPage<'a> {
                         child.detach();
                     });
 
+                    let element_data = node.as_element().unwrap();
+                    let element_name = element_data.name.local.to_string();
+                    let should_prevent_wrap = UNSUPPORTED_WRAP_ELEMENTS.contains(&element_name.as_str());
+
                     if let Some(content) = translation.get(key) {
                         let content = if content.contains('<') {
                             let mut rewriter = TranslationRewriter::new(
@@ -301,7 +307,7 @@ impl<'a> RoseyPage<'a> {
                             let _ = tokenizer.feed(&mut buffer);
                             tokenizer.end();
                             rewriter.finish()
-                        } else if self.should_wrap {
+                        } else if self.should_wrap && !should_prevent_wrap {
                             content
                                 .as_str()
                                 .segment_str()


### PR DESCRIPTION
Rosey shouldn't insert HTML into elements whose content models don't allow non-Text children.