### PR TITLE
Add Alternate self referencing

### DIFF
--- a/rosey/features/build/rosey-build-meta.feature
+++ b/rosey/features/build/rosey-build-meta.feature
@@ -39,6 +39,10 @@ Feature: Rosey Build Meta
       | hreflang | nada             |
 
     Then I should see a selector 'link' in "dist/translated_site/en/about.html" with the attributes:
+      | rel      | alternate      |
+      | href     | /en/about.html |
+      | hreflang | en             |
+    Then I should see a selector 'link' in "dist/translated_site/en/about.html" with the attributes:
       | rel      | alternate         |
       | href     | /blank/about.html |
       | hreflang | blank             |
@@ -46,6 +50,10 @@ Feature: Rosey Build Meta
       | rel      | alternate        |
       | href     | /nada/about.html |
       | hreflang | nada             |
+    Then I should see a selector 'link' in "dist/translated_site/blank/about.html" with the attributes:
+      | rel      | alternate         |
+      | href     | /blank/about.html |
+      | hreflang | blank             |
     Then I should see a selector 'link' in "dist/translated_site/blank/about.html" with the attributes:
       | rel      | alternate      |
       | href     | /en/about.html |
@@ -57,12 +65,20 @@ Feature: Rosey Build Meta
 
     Then I should see a selector 'link' in "dist/translated_site/en/index.html" with the attributes:
       | rel      | alternate |
+      | href     | /en/   |
+      | hreflang | en     |
+    Then I should see a selector 'link' in "dist/translated_site/en/index.html" with the attributes:
+      | rel      | alternate |
       | href     | /blank/   |
       | hreflang | blank     |
     Then I should see a selector 'link' in "dist/translated_site/en/index.html" with the attributes:
       | rel      | alternate |
       | href     | /nada/    |
       | hreflang | nada      |
+    Then I should see a selector 'link' in "dist/translated_site/blank/index.html" with the attributes:
+      | rel      | alternate |
+      | href     | /blank/   |
+      | hreflang | blank     |
     Then I should see a selector 'link' in "dist/translated_site/blank/index.html" with the attributes:
       | rel      | alternate |
       | href     | /en/      |

--- a/rosey/src/runners/builder/html.rs
+++ b/rosey/src/runners/builder/html.rs
@@ -564,6 +564,22 @@ impl<'a> RoseyPage<'a> {
         };
         meta_node.insert_after(NodeRef::new_text(&indentation));
 
+        let mut attributes = BTreeMap::new();
+        attributes.insert(
+            ExpandedName::new("", "rel"),
+            Attribute {
+                prefix: None,
+                value: String::from("alternate"),
+            },
+        );
+        let locale_key_node = NodeRef::new_element(
+            QualName::new(None, ns!(html), local_name!("link")),
+            attributes,
+        );
+        self.link_tags.push(locale_key_node.clone());
+        meta_node.insert_after(locale_key_node.clone());
+        meta_node.insert_after(NodeRef::new_text(&indentation));
+
         for _i in 0..self.translations.len() {
             let mut attributes = BTreeMap::new();
             attributes.insert(
@@ -606,7 +622,6 @@ impl<'a> RoseyPage<'a> {
             .iter()
             .map(|(key, _)| key.as_str())
             .chain(std::iter::once(&self.default_language[..]))
-            .filter(|key| *key != locale_key)
             .enumerate()
         {
             let translated_path = url_translations

--- a/rosey/src/runners/builder/html.rs
+++ b/rosey/src/runners/builder/html.rs
@@ -564,23 +564,7 @@ impl<'a> RoseyPage<'a> {
         };
         meta_node.insert_after(NodeRef::new_text(&indentation));
 
-        let mut attributes = BTreeMap::new();
-        attributes.insert(
-            ExpandedName::new("", "rel"),
-            Attribute {
-                prefix: None,
-                value: String::from("alternate"),
-            },
-        );
-        let locale_key_node = NodeRef::new_element(
-            QualName::new(None, ns!(html), local_name!("link")),
-            attributes,
-        );
-        self.link_tags.push(locale_key_node.clone());
-        meta_node.insert_after(locale_key_node.clone());
-        meta_node.insert_after(NodeRef::new_text(&indentation));
-
-        for _i in 0..self.translations.len() {
+        for _i in 0..=self.translations.len() {
             let mut attributes = BTreeMap::new();
             attributes.insert(
                 ExpandedName::new("", "rel"),


### PR DESCRIPTION
Each language version must list itself as well as all other language versions.

Here is the [guidelines](https://developers.google.com/search/docs/specialty/international/localized-versions#all-method-guidelines)

ex: a page /en/about/ localized in fr and de, should always have all three alternates links

```html
<link rel="alternate" hreflang="en" href="/en/about/">
<link rel="alternate" hreflang="fr" href="/fr/about/">
<link rel="alternate" hreflang="de" href="/de/about/">
```

@bglw If you have better way to add the locale_key to the loop don't hesitate!