### PR TITLE
Fix/url rewriting on existing pages

### DIFF
--- a/rosey/features/build/rosey-build-complex.feature
+++ b/rosey/features/build/rosey-build-complex.feature
@@ -199,21 +199,29 @@ Feature: Rosey Build Complex
       <html>
       <body>
       <div data-rosey="seal"><p>Kiss From A Rose</p></div>
+      <div data-rosey="frog"><p>Frog</p></div>
+      <div data-rosey="dog"><p>Dog</p></div>
       </body>
       </html>
       """
     And I have a "rosey/locales/jp.json" file with the content:
       """
       {
-        "seal": "これはリンクです <a href=\"/other.html\"/>"
+        "seal": "これはリンクです <a href=\"/other.html\"/>",
+        "frog": "これはリンクです <a href=\"/jp/other.html\"/>",
+        "dog": "これはリンクです <a href=\"/jparty/other.html\"/>"
       }
       """
     When I run my program with the flags:
       | build |
     Then I should see a selector 'div > p' in "dist/translated_site/en/index.html" with the attributes:
       | innerText | Kiss From A Rose |
-    And I should see a selector 'a' in "dist/translated_site/jp/index.html" with the attributes:
+    And I should see a selector '[data-rosey=seal] a' in "dist/translated_site/jp/index.html" with the attributes:
       | href | /jp/other.html |
+    And I should see a selector '[data-rosey=frog] a' in "dist/translated_site/jp/index.html" with the attributes:
+      | href | /jp/other.html |
+    And I should see a selector '[data-rosey=dog] a' in "dist/translated_site/jp/index.html" with the attributes:
+      | href | /jp/jparty/other.html |
     But I should not see a selector 'img' in "dist/translated_site/en/index.html"
 
   Scenario: Rosey build uses translated srcsets inside HTML translations

--- a/rosey/features/build/rosey-build-links.feature
+++ b/rosey/features/build/rosey-build-links.feature
@@ -17,6 +17,9 @@ Feature: Rosey Links
       <h6><a href="/posts/hello-world.html">Hello World Extension</a></h6>
       <h7><a href="/posts/hello-world/#title">Hello World Anchor</a></h7>
       <h8><a href="/posts/hello-world.html?q=a">Hello World Query</a></h8>
+      <h9><a href="/blank-posts/hello-world.html?q=a">Should not match blank locale</a></h9>
+      <h10><a href="/blank/hello-world.html?q=a">Stay the same</a></h10>
+      <h11><a href="/blank">Stay the same</a></h11>
       </body>
       </html>
       """
@@ -49,7 +52,16 @@ Feature: Rosey Links
       | innerText | Hello World Anchor              |
     Then I should see a selector 'h8>a' in "dist/translated_site/blank/index.html" with the attributes:
       | href      | /blank/posts/hello-world.html?q=a |
-      | innerText | Hello World Query                 |
+      | innerText | Hello World Query                 | 
+    Then I should see a selector 'h9>a' in "dist/translated_site/blank/index.html" with the attributes:
+      | href      | /blank/blank-posts/hello-world.html?q=a |
+      | innerText | Should not match blank locale            |
+    Then I should see a selector 'h10>a' in "dist/translated_site/blank/index.html" with the attributes:
+      | href      | /blank/hello-world.html?q=a |
+      | innerText | Stay the same               |
+    Then I should see a selector 'h11>a' in "dist/translated_site/blank/index.html" with the attributes:
+      | href      | /blank                      |
+      | innerText | Stay the same               |
 
 
   Scenario: Rosey doesn't update links already pointing to a locale

--- a/rosey/src/runners/builder/html.rs
+++ b/rosey/src/runners/builder/html.rs
@@ -320,7 +320,7 @@ impl<'a> RoseyPage<'a> {
                     .translations
                     .keys()
                     .chain(std::iter::once(&self.default_language))
-                    .any(|key| src.starts_with(&format!("/{key}")))
+                    .any(|key| src.starts_with(&format!("/{key}/")) || src == format!("/{key}"))
             {
                 self.anchor_tags
                     .push((src.to_string(), element.as_node().clone()));

--- a/rosey/src/runners/builder/html/utils.rs
+++ b/rosey/src/runners/builder/html/utils.rs
@@ -131,7 +131,7 @@ impl<'a> TokenSink for &mut TranslationRewriter<'a> {
                                     .translations
                                     .keys()
                                     .chain(std::iter::once(&self.default_language.to_string()))
-                                    .any(|key| attr.value.starts_with(&format!("/{key}")))
+                                    .any(|key| attr.value.starts_with(&format!("/{key}/")) || attr.value == format!("/{key}").into())
                             {
                                 self.result.push_str(&attr.value);
                             } else {


### PR DESCRIPTION
Fix for [Issue #112](https://github.com/CloudCannon/rosey/issues/112)

This pull request expands and refines the handling of localized links in the Rosey build system, especially around matching and transforming URLs for different locales. The main changes enhance test coverage for edge cases and update the logic for identifying locale-prefixed links, ensuring more accurate translation and link rewriting.

**Enhancements to link and locale handling:**

* Updated the logic in `html.rs` and `html/utils.rs` to more precisely detect locale-prefixed URLs, now matching both `/{locale}/...` and `/{locale}` exactly, which prevents incorrect rewriting of links that match a locale slug without a trailing slash. [[1]](diffhunk://#diff-401f5ff9454cf6b8c282f40846a46fa8a4f9d451e1ca536b5f2d438c7c626c2bL323-R323) [[2]](diffhunk://#diff-31ed9cca4398e84ad7c22508fc9565eb82526f1c1b7009adb9d491b5f546b0a4L134-R134)

**Expanded test coverage for link translation:**

* Added new test cases to `rosey-build-links.feature` to cover scenarios where links should or should not be rewritten for the "blank" locale, including links that exactly match a locale slug or have different path structures. [[1]](diffhunk://#diff-a122ecf46b999e94dc1f8f9d9908ac9ea18c6a0f0b42c2468cb38490da09c901R20-R22) [[2]](diffhunk://#diff-a122ecf46b999e94dc1f8f9d9908ac9ea18c6a0f0b42c2468cb38490da09c901R56-R64)
* Enhanced the `rosey-build-complex.feature` to include additional HTML elements and corresponding translations, and refined selector checks to verify correct translation and link rewriting for multiple elements.